### PR TITLE
Fix Clang build

### DIFF
--- a/recipes/opene57/all/CMakeLists.txt
+++ b/recipes/opene57/all/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.1)
+project(cmake_wrapper)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup(KEEP_RPATHS)
+
+add_subdirectory("source_subfolder")

--- a/recipes/opene57/all/conandata.yml
+++ b/recipes/opene57/all/conandata.yml
@@ -2,3 +2,7 @@ sources:
   "1.6.1":
     sha256: 898b9227aa844154099fdfa9123b8ed80f09e11b70ddbc0b7b84e54e3b01670c
     url: https://github.com/openE57/openE57/archive/refs/tags/1.6.1.tar.gz
+patches:
+  "1.6.1":
+    - patch_file: "patches/0001-source-folder.patch"
+      base_path: "source_subfolder"

--- a/recipes/opene57/all/conanfile.py
+++ b/recipes/opene57/all/conanfile.py
@@ -12,20 +12,25 @@ class Opene57Conan(ConanFile):
     homepage = "https://github.com/openE57/openE57"
     license = ("MIT", "BSL-1.0")
     settings = "os", "compiler", "arch", "build_type"
-    options = {"with_tools": [True, False],
-               "shared": [True, False],
-               "fPIC": [True, False]}
+    options = { "with_tools": [True, False],
+                "shared": [True, False],
+                "fPIC": [True, False]
+               }
     default_options = {
-        'with_tools': False,
-        'shared': False,
-        'fPIC': True}
-    exports_sources = "CMakeLists.txt"
+                "with_tools": False,
+                "shared": False,
+                "fPIC": True
+               }
     generators = "cmake", "cmake_find_package"
     _cmake = None
 
     @property
     def _source_subfolder(self):
         return "source_subfolder"
+
+    @property
+    def _build_subfolder(self):
+        return "build_subfolder"
 
     @property
     def _minimum_compilers_version(self):
@@ -35,6 +40,11 @@ class Opene57Conan(ConanFile):
             "clang": "6",
             "apple-clang": "10",
         }
+
+    def export_sources(self):
+        self.copy("CMakeLists.txt")
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            self.copy(patch["patch_file"])
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -54,14 +64,6 @@ class Opene57Conan(ConanFile):
             self.output.warn("C++17 support required. Your compiler is unknown. Assuming it supports C++17.")
         elif tools.Version(self.settings.compiler.version) < minimum_version:
             raise ConanInvalidConfiguration("C++17 support required, which your compiler does not support.")
-
-        # Check stdlib ABI compatibility
-        compiler_name = str(self.settings.compiler)
-        if compiler_name == "gcc" and self.settings.compiler.libcxx != "libstdc++11":
-            raise ConanInvalidConfiguration('Using %s with GCC requires "compiler.libcxx=libstdc++11"' % self.name)
-        elif compiler_name == "clang" and self.settings.compiler.libcxx not in ["libstdc++11", "libc++"]:
-            raise ConanInvalidConfiguration('Using %s with Clang requires either "compiler.libcxx=libstdc++11"'
-                                            ' or "compiler.libcxx=libc++"' % self.name)
 
     def build_requirements(self):
         if self.options.with_tools:
@@ -84,6 +86,7 @@ class Opene57Conan(ConanFile):
         if self._cmake:
             return self._cmake
         self._cmake = CMake(self)
+        self._cmake.verbose = True
         self._cmake.definitions["PROJECT_VERSION"] = self.version
         self._cmake.definitions["BUILD_EXAMPLES"] = False
         self._cmake.definitions["BUILD_TOOLS"] = self.options.with_tools
@@ -91,11 +94,13 @@ class Opene57Conan(ConanFile):
         if self.settings.os == "Windows":
             self._cmake.definitions["BUILD_WITH_MT"] = "MT" in str(msvc_runtime_flag(self))
         else:
-            self._cmake.definitions["BUILD_WITH_FPIC"] = self.options.fPIC
-        self._cmake.configure(source_folder=self._source_subfolder)
+            self._cmake.definitions["BUILD_WITH_FPIC"] = self.options.get_safe("fPIC", True)
+        self._cmake.configure(build_folder=self._build_subfolder)
         return self._cmake
 
     def build(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
         cmake = self._configure_cmake()
         cmake.build()
 

--- a/recipes/opene57/all/conanfile.py
+++ b/recipes/opene57/all/conanfile.py
@@ -86,7 +86,6 @@ class Opene57Conan(ConanFile):
         if self._cmake:
             return self._cmake
         self._cmake = CMake(self)
-        self._cmake.verbose = True
         self._cmake.definitions["PROJECT_VERSION"] = self.version
         self._cmake.definitions["BUILD_EXAMPLES"] = False
         self._cmake.definitions["BUILD_TOOLS"] = self.options.with_tools

--- a/recipes/opene57/all/patches/0001-source-folder.patch
+++ b/recipes/opene57/all/patches/0001-source-folder.patch
@@ -17,18 +17,6 @@ index b8ae7d9..6c55e87 100644
          DESTINATION .)
  
  set(CPACK_PACKAGE_VENDOR "Michele Adduci <adduci@tutanota.com>")
-diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index a489d6b..29dbf46 100644
---- a/src/CMakeLists.txt
-+++ b/src/CMakeLists.txt
-@@ -13,7 +13,6 @@ include(GenerateExportHeader)
- # Check if we are building a conan recipe
- #if(NOT EXISTS ${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
- #include(InstallRequiredSystemLibraries)
--include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/compiler_options.cmake)
- #endif()
- 
- include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/dependencies.cmake)
 diff --git a/src/tools/CMakeLists.txt b/src/tools/CMakeLists.txt
 index baa5281..2d26bcb 100644
 --- a/src/tools/CMakeLists.txt

--- a/recipes/opene57/all/patches/0001-source-folder.patch
+++ b/recipes/opene57/all/patches/0001-source-folder.patch
@@ -1,0 +1,53 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b8ae7d9..6c55e87 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -72,12 +72,12 @@ if(NOT CMAKE_BUILD_TYPE)
+   set(CMAKE_BUILD_TYPE "Release")
+ endif()
+ 
+-add_subdirectory(${CMAKE_SOURCE_DIR}/src)
++add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/src)
+ 
+ # 
+ # Install Artifacts
+ #
+-install(FILES ${CMAKE_SOURCE_DIR}/CHANGELOG.md
++install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/CHANGELOG.md
+         DESTINATION .)
+ 
+ set(CPACK_PACKAGE_VENDOR "Michele Adduci <adduci@tutanota.com>")
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index a489d6b..29dbf46 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -13,7 +13,6 @@ include(GenerateExportHeader)
+ # Check if we are building a conan recipe
+ #if(NOT EXISTS ${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+ #include(InstallRequiredSystemLibraries)
+-include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/compiler_options.cmake)
+ #endif()
+ 
+ include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/dependencies.cmake)
+diff --git a/src/tools/CMakeLists.txt b/src/tools/CMakeLists.txt
+index baa5281..2d26bcb 100644
+--- a/src/tools/CMakeLists.txt
++++ b/src/tools/CMakeLists.txt
+@@ -51,7 +51,7 @@ foreach(TOOL ${TOOLS})
+   target_include_directories(${TOOL} 
+     PRIVATE 
+       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+-      ${CMAKE_SOURCE_DIR}/src/lib/include
++      ${CMAKE_CURRENT_SOURCE_DIR}/src/lib/include
+       ${XML_INCLUDE_DIRS}
+       ${Boost_INCLUDE_DIR}
+   )
+@@ -80,7 +80,7 @@ target_link_options(las2e57 PUBLIC ${linker_flags})
+ target_include_directories(las2e57
+   PRIVATE 
+     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+-    ${CMAKE_SOURCE_DIR}/src/lib/include
++    ${CMAKE_CURRENT_SOURCE_DIR}/src/lib/include
+     ${XML_INCLUDE_DIRS}
+     ${Boost_INCLUDE_DIR}
+ )

--- a/recipes/opene57/all/test_package/CMakeLists.txt
+++ b/recipes/opene57/all/test_package/CMakeLists.txt
@@ -8,5 +8,4 @@ find_package(opene57 REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} example.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE opene57::opene57)
-target_include_directories(${PROJECT_NAME} PRIVATE ${opene57_INCLUDE_DIRS})
 set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 17)

--- a/recipes/opene57/all/test_package/conanfile.py
+++ b/recipes/opene57/all/test_package/conanfile.py
@@ -1,5 +1,4 @@
 import os
-from conan.tools.microsoft import msvc_runtime_flag
 from conans import ConanFile, CMake, tools
 
 class TestOpenE57Conan(ConanFile):
@@ -7,11 +6,9 @@ class TestOpenE57Conan(ConanFile):
     generators = "cmake", "cmake_find_package_multi"
 
     def build(self):
-        if not tools.cross_building(self):
-            cmake = CMake(self)
-            cmake.definitions["BUILD_WITH_MT"] = "MT" in str(msvc_runtime_flag(self))
-            cmake.configure()
-            cmake.build()
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
 
     def test(self):
         if not tools.cross_building(self):


### PR DESCRIPTION
Some important points:

- The Conan CMake helper needs to load the `conanbuildinfo.cmake` file, otherwise, it won't recipe the cmake definition according your current profile, creating a mess between what you asked to build and the configuration generated.
- We add a CMakeLists.txt as wrapper to load conanbuildinfo.cmake, so we don't need to touch the upstream's Cmake file
- As the src/Cmakelists.txt uses CMAKE_SOURCE_DIR, but conan uses an outside path, we need a patch to replace it by CMAKE_CURRENT_SOURCE_DIR
- Once the configuration is loaded according, all profiles should work, including gcc + libstdc++, so you no longer need to drop them
- You still can cross-build test_package, you just can't run due the incompatible architecture.

I tested it on Linux and Windows, I hope it will pass at first try. 

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
